### PR TITLE
fix(_tokenize): cross-platform hash stability issues of float and dict types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,33 @@ from stablehash import stablehash
 assert stablehash({"key": "value"}, algorithm="md5").hexdigest() == 'd5994850379366e314563ea555532052'
 ```
 
+## Compatibility notes
+
+### Since `0.3.x`
+Hashing semantics are changed for certain inputs to improve stability:
+
+* Dictionaries now hash independent of key insertion order (i.e., equal dicts produce the same digest regardless of the order keys were added).  
+* Serialize floats as IEEE-754 64-bit little-endian (`struct.pack('<d', x)`) to guarantee cross-platform stable digests.  
+
+These changes may cause the digest produced for the same value to **differ from** the `0.2.x` series. The public API is unchanged, but we treat changes that alter produced hashes as breaking from a user's perspective. (See PR [#20](https://github.com/NiklasRosenstein/python-stablehash/pull/20) for background.)
+
+<details>
+
+<summary>
+<b>What should downstream users do?</b>
+</summary>
+
+* If your project depends on exact hash outputs (for example, using them as file identifiers or data fingerprints), either:  
+
+  * pin an **upper bound** to the previous minor series: `stablehash >=0.2.0, <0.3.0`, or  
+  * upgrade to `0.3.x` and **re-generate** your stored hashes.     
+
+</details>
+
+## Versioning policy
+
+This project follows Semantic Versioning where applicable. During initial development (`0.y.z`), the public API should not be considered stable and **breaking changes may occur in a minor bump**. We therefore use the minor version to signal changes that can alter produced digests (semantic changes). Downstream users are encouraged to **specify an upper bound** on the minor version when depending on `0.y.z` releases. 
+
 ## API
 
 ### `stablehash(obj=..., *, algorithm="blake2b")`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ default internal hash algorithm is Blake2b, but this can be changed by passing a
 ```python
 from stablehash import stablehash
 
-assert stablehash({"key": "value"}, algorithm="md5").hexdigest() == 'd5994850379366e314563ea555532052'
+assert stablehash({"key": "value"}, algorithm="md5").hexdigest() == "0ea2506ffbeef2699760d422d7a8b971"
 ```
 
 ## Compatibility notes

--- a/src/stablehash/__init__test.py
+++ b/src/stablehash/__init__test.py
@@ -5,6 +5,42 @@ from uuid import UUID
 
 from stablehash import stablehash
 
+_nested_dict_1 = {
+    1: "int",
+    "key": {
+        "b": "k",
+        "a": "val",
+        "nested": {
+            "x": [1, 2, {"m": 10, "n": [3, 4, 5]}],
+            "y": {"tuple": (1, 2, 3), "set": {3, 2, 1}},
+        },
+    },
+    "k": "v",
+    (1, 2): "233",
+    "complex": {
+        ("tuple", 42): {"inner": {True: "yes", None: "nil"}},
+        frozenset({1, 2, 3}): "frozen",
+    },
+}
+
+_nested_dict_2 = {
+    "complex": {
+        frozenset({3, 2, 1}): "frozen",
+        ("tuple", 42): {"inner": {None: "nil", True: "yes"}},
+    },
+    (1, 2): "233",
+    1: "int",
+    "k": "v",
+    "key": {
+        "a": "val",
+        "b": "k",
+        "nested": {
+            "y": {"set": {1, 3, 2}, "tuple": (1, 2, 3)},
+            "x": [1, 2, {"n": [3, 4, 5], "m": 10}],
+        },
+    },
+}
+
 
 @dataclass
 class MyDataclass:
@@ -23,7 +59,8 @@ class Picklable:
 
 def test__stablehash() -> None:
     assert stablehash(42, algorithm="md5").hexdigest() == "6d2cdfd21468e0ec822bcfbefc38c73d"
-    assert stablehash({"key": "value"}, algorithm="md5").hexdigest() == "d5994850379366e314563ea555532052"
+    assert stablehash({"key": "value"}, algorithm="md5").hexdigest() == "0ea2506ffbeef2699760d422d7a8b971"
+    assert stablehash(_nested_dict_1, algorithm="md5").hexdigest() == stablehash(_nested_dict_2, algorithm="md5").hexdigest() == "2e510913c66105a8dd563e5111e3c809"
     assert stablehash([1, 2, 3], algorithm="md5").hexdigest() == "c8b541e613f5e7708f0553221e2725d5"
     assert stablehash((1, 2, 3), algorithm="md5").hexdigest() == "f1a8fe053f96bb01977d521912b3132f"
     assert stablehash({1, 2, 3}, algorithm="md5").hexdigest() == "10bf2edb0a4badb2aa27e29fff846f46"

--- a/src/stablehash/__init__test.py
+++ b/src/stablehash/__init__test.py
@@ -60,7 +60,11 @@ class Picklable:
 def test__stablehash() -> None:
     assert stablehash(42, algorithm="md5").hexdigest() == "6d2cdfd21468e0ec822bcfbefc38c73d"
     assert stablehash({"key": "value"}, algorithm="md5").hexdigest() == "0ea2506ffbeef2699760d422d7a8b971"
-    assert stablehash(_nested_dict_1, algorithm="md5").hexdigest() == stablehash(_nested_dict_2, algorithm="md5").hexdigest() == "2e510913c66105a8dd563e5111e3c809"
+    assert (
+        stablehash(_nested_dict_1, algorithm="md5").hexdigest() 
+        == stablehash(_nested_dict_2, algorithm="md5").hexdigest() 
+        == "2e510913c66105a8dd563e5111e3c809"
+    )
     assert stablehash([1, 2, 3], algorithm="md5").hexdigest() == "c8b541e613f5e7708f0553221e2725d5"
     assert stablehash((1, 2, 3), algorithm="md5").hexdigest() == "f1a8fe053f96bb01977d521912b3132f"
     assert stablehash({1, 2, 3}, algorithm="md5").hexdigest() == "10bf2edb0a4badb2aa27e29fff846f46"
@@ -74,7 +78,7 @@ def test__stablehash() -> None:
     )
     assert stablehash(date(2021, 1, 1), algorithm="md5").hexdigest() == "a8d008bc6c73f527333b3d40726c7e1f"
     assert stablehash(time(0, 0, 0), algorithm="md5").hexdigest() == "531c98aced815358bb7375c5948d0d82"
-    assert stablehash(timedelta(seconds=1), algorithm="md5").hexdigest() == "e5fe3b7bf1b4ca1fb9ba5bfe886fbff5"
+    assert stablehash(timedelta(seconds=1), algorithm="md5").hexdigest() == "7babeee6b6b1e1c94e5bbd6eed14811e"
     assert (
         stablehash(UUID("00000000-0000-0000-0000-000000000000"), algorithm="md5").hexdigest()
         == "34fa1fac0804eaebe1a8a3adce7cef3f"

--- a/src/stablehash/__init__test.py
+++ b/src/stablehash/__init__test.py
@@ -62,8 +62,8 @@ def test__stablehash() -> None:
     assert stablehash(42, algorithm="md5").hexdigest() == "6d2cdfd21468e0ec822bcfbefc38c73d"
     assert stablehash({"key": "value"}, algorithm="md5").hexdigest() == "0ea2506ffbeef2699760d422d7a8b971"
     assert (
-        stablehash(_nested_dict_1, algorithm="md5").hexdigest() 
-        == stablehash(_nested_dict_2, algorithm="md5").hexdigest() 
+        stablehash(_nested_dict_1, algorithm="md5").hexdigest()
+        == stablehash(_nested_dict_2, algorithm="md5").hexdigest()
         == "2e510913c66105a8dd563e5111e3c809"
     )
     assert stablehash([1, 2, 3], algorithm="md5").hexdigest() == "c8b541e613f5e7708f0553221e2725d5"

--- a/src/stablehash/__init__test.py
+++ b/src/stablehash/__init__test.py
@@ -23,6 +23,7 @@ _nested_dict_1 = {
     },
 }
 
+# Same as _nested_dict_1 but with the order of keys in dictionaries shuffled.
 _nested_dict_2 = {
     "complex": {
         frozenset({3, 2, 1}): "frozen",

--- a/src/stablehash/_tokenize.py
+++ b/src/stablehash/_tokenize.py
@@ -62,7 +62,7 @@ def tokenize(hasher: "Hasher", x: Any, *, header: bool = True) -> None:
             for item_hash in item_hashes:
                 hasher.update(item_hash)
         case dict():
-            for key, value in x.items():
+            for key, value in sorted(x.items()):
                 tokenize(hasher, key)
                 tokenize(hasher, value)
         case Dataclass():

--- a/src/stablehash/_tokenize.py
+++ b/src/stablehash/_tokenize.py
@@ -36,7 +36,7 @@ def tokenize(hasher: "Hasher", x: Any, *, header: bool = True) -> None:
             bits = x.bit_length() // 8 + 1
             hasher.update(x.to_bytes(bits, "little", signed=True))
         case float():
-            hasher.update(struct.pack("f", x))
+            hasher.update(struct.pack("<d", x))
         case str():
             # TODO(@niklas): Is there any way we can grab the actual in-memory representation of the string
             #   instead of encoding it? That should yield significant performance improvements. We could

--- a/src/stablehash/_tokenize.py
+++ b/src/stablehash/_tokenize.py
@@ -62,9 +62,21 @@ def tokenize(hasher: "Hasher", x: Any, *, header: bool = True) -> None:
             for item_hash in item_hashes:
                 hasher.update(item_hash)
         case dict():
-            for key, value in sorted(x.items()):
-                tokenize(hasher, key)
-                tokenize(hasher, value)
+            pair_hashes = []
+            for key, value in x.items():
+                pair_hasher = hasher.copy()
+
+                tokenize(pair_hasher, key)
+                tokenize(pair_hasher, value)
+
+                # Hash to make pairs comparable
+                pair_hashes.append(pair_hasher.digest()) 
+
+            # Sort the hashes to ensure order-independence
+            pair_hashes.sort()  
+
+            for h in pair_hashes:
+                hasher.update(h)
         case Dataclass():
             for field in fields(x):
                 tokenize(hasher, field.name)

--- a/src/stablehash/_tokenize.py
+++ b/src/stablehash/_tokenize.py
@@ -70,10 +70,10 @@ def tokenize(hasher: "Hasher", x: Any, *, header: bool = True) -> None:
                 tokenize(pair_hasher, value)
 
                 # Hash to make pairs comparable
-                pair_hashes.append(pair_hasher.digest()) 
+                pair_hashes.append(pair_hasher.digest())
 
             # Sort the hashes to ensure order-independence
-            pair_hashes.sort()  
+            pair_hashes.sort()
 
             for h in pair_hashes:
                 hasher.update(h)


### PR DESCRIPTION
It seems that stablehash will generate different hash values for dictionaries that are semantically identical but have a different key insertion order.  

Reproduce:   

```python
from stablehash import stablehash

dict1 = {"k": "v", "key": "value"}
dict2 = {"key": "value", "k": "v"}

hash1 = stablehash(dict1, algorithm='md5').hexdigest()
hash2 = stablehash(dict2, algorithm='md5').hexdigest()

print(f"Hash 1: {hash1}")
print(f"Hash 2: {hash2}")
print(f"Hashes are equal: {hash1 == hash2}")  

# Expected output:
# Hashes are equal: True

# Actual output:
# Hash 1: 18fe582b10a2d8a36d70a340e033d0ae
# Hash 2: dce540f2c09be4826874cbd2a8b4530f
# Hashes are equal: False
```

Related doc: https://docs.python.org/3.11/library/stdtypes.html#dict-views    

And I think the problem may lie here: https://github.com/NiklasRosenstein/python-stablehash/blob/d9e3290386437388b4ae9af04731f98c125ca986/src/stablehash/_tokenize.py#L64C9-L67C40 .  

To solve the issue, I wrapped the dict `items()` with `sorted` function to sort the key-value pairs before tokenizing, hope this helps. Thank you for developing this small but useful package!  